### PR TITLE
Android: Lifecycle event listener

### DIFF
--- a/android/src/main/java/com/yunpeng/react/webview/YPWebViewManager.java
+++ b/android/src/main/java/com/yunpeng/react/webview/YPWebViewManager.java
@@ -1,19 +1,33 @@
 package com.yunpeng.react.webview;
 
+import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.views.webview.ReactWebViewManager;
 import com.facebook.react.views.webview.WebViewConfig;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.uimanager.ThemedReactContext;
 
-import android.net.http.SslError;
 import android.webkit.WebView;
-import android.webkit.WebViewClient;
-import android.webkit.SslErrorHandler;
-import android.content.res.Resources;
 
 @ReactModule(name = YPWebViewManager.REACT_CLASS)
-public class YPWebViewManager extends ReactWebViewManager {
+public class YPWebViewManager extends ReactWebViewManager implements LifecycleEventListener {
+
+  private WebView webView;
+
+  @Override
+  public void onHostPause() {
+    this.webView.onPause();
+  }
+
+  @Override
+  public void onHostDestroy() {
+    //Do nothing
+  }
+
+  @Override
+  public void onHostResume() {
+    this.webView.onResume();
+  }
 
   protected static final String REACT_CLASS = "RCTYPWebView";
 
@@ -31,10 +45,6 @@ public class YPWebViewManager extends ReactWebViewManager {
   }
 
   protected static class YPWebViewClient extends ReactWebViewClient {
-    @Override
-    public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError error) {
-      handler.proceed();
-    }
   }
 
   @ReactProp(name = "scalesPageToFit")


### PR DESCRIPTION
It is required in order to meet android web requirement of auto pause/play video in `WebView` when app state is being changed between background/foreground. Without this apps are being rejected.